### PR TITLE
fix: Drop ssh_connection settings from .ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,3 @@ stdout_callback = yaml
 
 [inventory]
 enable_plugins = ini
-
-[ssh_connection]
-ssh_args = -C -o UserKnownHostsFile=/dev/null


### PR DESCRIPTION
Operating with `UserKnownHostsFile=/dev/null` is not good security
practice; we should not encourage it.
