### PR TITLE
fix: Allow ICMP ingress

### DIFF
--- a/default_ingress.yml
+++ b/default_ingress.yml
@@ -4,7 +4,23 @@
   gather_facts: false
 
   tasks:
-    - name: Add IPv4 ingress rules to default security group
+    - name: Add IPv4 ICMP ingress rules to default security group
+      openstack.cloud.security_group_rule:
+        security_group: default
+        direction: ingress
+        protocol: icmp
+        ether_type: IPv4
+        remote_ip_prefix: 0.0.0.0/0
+
+    - name: Add IPv6 ICMP ingress rules to default security group
+      openstack.cloud.security_group_rule:
+        security_group: default
+        direction: ingress
+        protocol: icmp
+        ether_type: IPv6
+        remote_ip_prefix: ::/0
+
+    - name: Add IPv4 TCP ingress rules to default security group
       openstack.cloud.security_group_rule:
         security_group: default
         direction: ingress
@@ -17,7 +33,7 @@
         - 22
         - 80
 
-    - name: Add IPv6 ingress rules to default security group
+    - name: Add IPv6 TCP ingress rules to default security group
       openstack.cloud.security_group_rule:
         security_group: default
         direction: ingress


### PR DESCRIPTION
There's no good reason to make a public server, which has open TCP ports, not pingable. Add the necessary ICMP ingress rules to allow incoming pings.
