### PR TITLE
Remove surrogate progress checks

### DIFF
--- a/default_ingress.yml
+++ b/default_ingress.yml
@@ -45,8 +45,3 @@
       with_items:
         - 22
         - 80
-
-    - name: Progress Check -- Ingress rules added
-      file:
-        path: ~/.prchk_ingress_rules_added
-        state: directory

--- a/keypair.yml
+++ b/keypair.yml
@@ -14,8 +14,3 @@
         name: ansible_key
         public_key_file: ansible_key.pub
         state: present
-
-    - name: Progress Check -- Public key uploaded
-      file:
-        path: ~/.prchk_public_key_uploaded
-        state: directory

--- a/networking.yml
+++ b/networking.yml
@@ -29,8 +29,3 @@
           - net: ansible_net
             subnet: ansible_subnet
             portip: 10.254.254.254
-
-    - name: Progress Check -- Networking setup complete
-      file:
-        path: ~/.prchk_networking_setup_complete
-        state: directory

--- a/server-1.yml
+++ b/server-1.yml
@@ -18,8 +18,3 @@
         auto_ip: true
         security_groups: default
         wait: true
-
-    - name: Progress Check -- Server created
-      file:
-        path: ~/.prchk_server_created
-        state: directory

--- a/server-2.yml
+++ b/server-2.yml
@@ -44,13 +44,3 @@
         upgrade: dist
         autoremove: true
         force_apt_get: true
-
-- hosts: localhost
-  connection: local
-  gather_facts: false
-
-  tasks:
-    - name: Progress Check -- Server packages upgraded
-      file:
-        path: ~/.prchk_server_packages_upgraded
-        state: directory

--- a/server-3.yml
+++ b/server-3.yml
@@ -53,13 +53,3 @@
     - name: Initiate system reboot
       reboot:
       when: reboot_required_file.stat.exists
-
-- hosts: localhost
-  connection: local
-  gather_facts: false
-
-  tasks:
-    - name: Progress Check -- Server reboot check done
-      file:
-        path: ~/.prchk_server_reboot_check_done
-        state: directory

--- a/server.yml
+++ b/server.yml
@@ -64,13 +64,3 @@
         name: nginx
         state: started
         enabled: true
-
-- hosts: localhost
-  connection: local
-  gather_facts: false
-
-  tasks:
-    - name: Progress Check -- Service installed and activated
-      file:
-        path: ~/.prchk_service_installed_and_activated
-        state: directory

--- a/teardown.yml
+++ b/teardown.yml
@@ -29,16 +29,3 @@
       openstack.cloud.keypair:
         name: ansible_key
         state: absent
-
-    - name: Remove checkpoints
-      file:
-        path: '{{ item }}'
-        state: absent
-      with_items:
-        - '~/.prchk_service_installed_and_activated'
-        - '~/.prchk_server_reboot_check_done'
-        - '~/.prchk_server_packages_upgraded'
-        - '~/.prchk_server_created'
-        - '~/.prchk_ingress_rules_added'
-        - '~/.prchk_networking_setup_complete'
-        - '~/.prchk_public_key_uploaded'


### PR DESCRIPTION
Now that we have "natural" progress checks in all labs, the semaphore
files are no longer needed.

This reverts commit https://github.com/citynetwork/ct111-playbooks/commit/712c1c1476c8c3bb82aa168a02818a5a6fd58951.