### PR TITLE
feat: Add requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+- name: "openstack.cloud"
+  version: ">=2.2.0"
+- name: "community.general"
+- name: "community.crypto"


### PR DESCRIPTION
Rather than relying on the `openstack.cloud` and `community.crypto` collections having been pre-installed with Ansible, drop a requirements file into the repository, so that learners can install the correct versions of those collections with `ansible-galaxy install -r requirements.yml`.

(This is a cherry-pick of https://github.com/citynetwork/ct112-playbooks/pull/6.)
