### PR TITLE
Use newer version of openstack.cloud collection, explicitly set ansible.cfg parameters

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,8 @@
 host_key_checking = False
 retry_files_enabled = False
 localhost_warning = False
-stdout_callback = yaml
+interpreter_python = auto_silent
+stdout_callback = ansible.builtin.default
 
 [inventory]
 enable_plugins = ini

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
 - name: "openstack.cloud"
-  version: ">=2.2.0"
+  version: ">=2.4.1"
 - name: "community.general"
 - name: "community.crypto"


### PR DESCRIPTION
We make sure to use a version of openstack.cloud collection that supports the `tags` keyword argument.

Also, we explicitly set specific parameters in `ansible.cfg` to avoid warnings regarding the deprecation of the `community.general.yaml` plugin, and the discovery of the local Python interpreter.