### PR TITLE
Update Heat templates to enable config_drive for server instances

### DIFF
--- a/server-1.yml
+++ b/server-1.yml
@@ -17,4 +17,5 @@
         network: ansible_net
         auto_ip: true
         security_groups: default
+        config_drive: true
         wait: true

--- a/server-2.yml
+++ b/server-2.yml
@@ -17,6 +17,7 @@
         network: ansible_net
         auto_ip: true
         security_groups: default
+        config_drive: true
         wait: true
       register: vm_info
 

--- a/server-3.yml
+++ b/server-3.yml
@@ -17,6 +17,7 @@
         network: ansible_net
         auto_ip: true
         security_groups: default
+        config_drive: true
         wait: true
       register: vm_info
 

--- a/server.yml
+++ b/server.yml
@@ -17,6 +17,7 @@
         network: ansible_net
         auto_ip: true
         security_groups: default
+        config_drive: true
         wait: true
       register: vm_info
 


### PR DESCRIPTION
Update template to use config-drive instead of metadata service for instance configuration